### PR TITLE
文档变更：替换新的npm镜像地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 yarn install
 
 electron 可能会安装失败, 执行下列命令后, 再次执行yarn install
-yarn config set ELECTRON_MIRROR=https://npm.taobao.org/mirrors/electron/
+yarn config set ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
 ```
 
 ### 启动项目


### PR DESCRIPTION
原淘宝npm镜像将弃用，改为新域名。
https://npmmirror.com/