### PR TITLE
修复 README 中的 Star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ pnpm run tauri build
 ## 点个 Star 支持我们 ⭐
 <p align='center'>
   <a href="https://github.com/Java-S12138/frank/stargazers">
-    <img src="https://api.star-history.com/svg?repos=Java-S12138/frank&type=Date">
+    <img src="https://star-history.dera.page/svg?repos=Java-S12138/frank&type=Date">
   </a>
 </p>


### PR DESCRIPTION
当前的 Star 历史图表因为 GitHub stargazer API 的限制已经失效，无法正常加载。本 PR 将其数据源切换到 star-history.dera.page，该方案无需 API token，即可继续正常展示项目的 Star 历史。