### PR TITLE
fix: resolve backend panics, template syntax bugs, and data calculation logic errors

### DIFF
--- a/src-tauri/src/lcu.rs
+++ b/src-tauri/src/lcu.rs
@@ -23,47 +23,52 @@ use tauri::{AppHandle, Emitter};
 static REST_CLIENT: OnceCell<RESTClient> = OnceCell::new();
 
 // 获取 REST_CLIENT 的函数
-fn get_client() -> Result<&'static RESTClient, String> {
+fn get_client() -> Result<&'static RESTClient, Value> {
     REST_CLIENT
         .get()
-        .ok_or_else(|| "REST_CLIENT is not initialized".to_string())
+        .ok_or(Value::Null)
 }
 
 #[tauri::command]
 pub async fn invoke_lcu(method: &str, uri: &str, body: &str) -> Result<Value, Value> {
     let client = get_client()?; // 获取全局的 REST_CLIENT
     if method == "get" {
-        let res = client.get(uri).await;
-        match res {
-            Ok(res) => return Ok(res),
-            Err(e) => return Err(Value::Null),
+        match client.get(uri).await {
+            Ok(res) => Ok(res),
+            Err(_) => Err(Value::Null),
         }
     } else if method == "patch" {
-        let parsed: Value = serde_json::from_str(body).expect("Failed to parse JSON string");
-        let _res = client.patch(uri, serde_json::json!(parsed)).await.unwrap();
+        let parsed = serde_json::from_str::<Value>(body).unwrap_or(Value::Null);
+        match client.patch(uri, parsed).await {
+            Ok(res) => Ok(res),
+            Err(_) => Err(Value::Null),
+        }
     } else if method == "post" {
-        let parsed = serde_json::from_str::<Value>(body);
-        match parsed {
-            Ok(parsed) => {
-                let _res = client.post(uri, parsed).await.unwrap();
-            }
-            Err(e) => {
-                let _res = client.post(uri, Value::Null).await.unwrap();
-            }
+        let parsed = serde_json::from_str::<Value>(body).unwrap_or(Value::Null);
+        match client.post(uri, parsed).await {
+            Ok(res) => Ok(res),
+            Err(_) => Err(Value::Null),
         }
     } else if method == "delete" {
-        let _res = client.delete(uri).await.unwrap();
+        match client.delete(uri).await {
+            Ok(res) => Ok(res),
+            Err(_) => Err(Value::Null),
+        }
+    } else {
+        Ok(Value::Null)
     }
-    Ok(Value::Null)
 }
 
 #[tauri::command]
 pub async fn get_match_list(uri: &str) -> Result<MatchListDetails, Value> {
     let client = get_client()?;
-    let res: Value = client.get(uri).await.expect("Failed to Url");
-    match from_value::<MatchListDetails>(res.clone()) {
+    let res = match client.get(uri).await {
+        Ok(res) => res,
+        Err(_) => return Err(Value::Null),
+    };
+    match from_value::<MatchListDetails>(res) {
         Ok(match_list) => Ok(match_list),
-        Err(e) => Err(Value::Null),
+        Err(_) => Err(Value::Null),
     }
 }
 
@@ -80,19 +85,20 @@ pub fn listen_for_client_start(app: AppHandle) {
     tokio::spawn({
         async move {
             let start_time = Instant::now();
-            let timeout = Duration::from_secs(180); // 设置一个超时时间，例如 30 秒
+            let timeout = Duration::from_secs(180); // 设置一个超时时间，例如 180 秒
 
             loop {
                 // 获取客户端信息
                 let is_exist = get_auth_info();
                 match is_exist {
                     Ok(value) => {
-                        let _ = REST_CLIENT
-                            .set(RESTClient::new(value.token, value.port).unwrap())
-                            .map_err(|_| "REST_CLIENT is already initialized".to_string());
-                        app.emit_to("background", "client_status", "ClientStarted")
-                            .expect("sent background error");
-                        break; // 找到客户端信息后退出循环
+                        if let Ok(client) = RESTClient::new(value.token, value.port) {
+                            let _ = REST_CLIENT
+                                .set(client)
+                                .map_err(|_| "REST_CLIENT is already initialized".to_string());
+                            let _ = app.emit_to("background", "client_status", "ClientStarted");
+                            break; // 找到客户端信息后退出循环
+                        }
                     }
                     Err(_) => {}
                 }
@@ -104,7 +110,7 @@ pub fn listen_for_client_start(app: AppHandle) {
                 }
 
                 // 每隔一段时间重新检查
-                thread::sleep(Duration::from_secs(3)); // 每秒钟检查一次
+                tokio::time::sleep(Duration::from_secs(3)).await;
             }
         }
     });

--- a/src/main/views/rank/index.vue
+++ b/src/main/views/rank/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {
   NCard, NAvatar, NSpace, NSelect, NBackTop,
-  NList, NListItem, NScrollbar, useMessage, NDropdown, NButton, NDrawer, arDZ
+  NList, NListItem, NScrollbar, useMessage, NDropdown, NButton, NDrawer
 } from 'naive-ui'
 import './assistCommon.css'
 import {onActivated, onDeactivated, onMounted, Ref, ref} from "vue";
@@ -56,19 +56,19 @@ const handlePosSelect = (pos:string) => {
   lane.value = pos
    queryChampRankData().then((value) => {
      switch (pos) {
-         case pos = 'top':
+         case 'top':
            message.success('上单数据更新成功')
            break;
-         case pos = 'jungle':
+         case 'jungle':
            message.success('打野数据更新成功')
            break;
-         case pos = 'mid':
+         case 'mid':
            message.success('中单数据更新成功')
            break;
-         case pos = 'bottom':
+         case 'bottom':
            message.success('下路数据更新成功')
            break;
-         case pos = 'support':
+         case 'support':
            message.success('辅助数据更新成功')
            break;
        }

--- a/src/main/views/rank/utils.ts
+++ b/src/main/views/rank/utils.ts
@@ -117,15 +117,15 @@ const toPercent = (point: number) => {
 // 获取对于的位置
 export const getPostion = (lane: string) => {
   switch (lane) {
-    case (lane = "top"):
+    case "top":
       return "0";
-    case (lane = "jungle"):
+    case "jungle":
       return "1";
-    case (lane = "mid"):
+    case "mid":
       return "2";
-    case (lane = "bottom"):
+    case "bottom":
       return "3";
-    case (lane = "support"):
+    case "support":
       return "4";
     default:
       return "2";

--- a/src/main/views/record/addBlackList.vue
+++ b/src/main/views/record/addBlackList.vue
@@ -15,7 +15,7 @@ import {
     HaterStructTypes,
     UserInfos,
 } from "@/main/views/record/blackListTypes";
-import { sumInfoTypes } from "@/background/utils/backgroundTypes";
+import { sumInfoTypes } from "@/background/types";
 import { createHaterContent, updatePlayerRecord } from "@/main/utils/request";
 import { useRecordStore } from "@/main/store/useRecord";
 

--- a/src/main/views/record/summonerEnd.vue
+++ b/src/main/views/record/summonerEnd.vue
@@ -1,4 +1,3 @@
-2
 <script setup lang="ts">
 import { NPopover, NTag, NIcon } from "naive-ui";
 import { ThumbDown, ThumbUp } from "@vicons/tabler";

--- a/src/main/views/rune/get101Runes.ts
+++ b/src/main/views/rune/get101Runes.ts
@@ -102,9 +102,10 @@ export const get101Runes = async (champId:string|number) => {
         return valueAtIndex4 >= 6000;
       })
 
-      var pages:any = filteredData.slice(0, 2).map((i:any) => makePerkData(i, champDict[champId].alias, position));
+      const pages:any = filteredData.slice(0, 2).map((i:any) => makePerkData(i, champDict[champId].alias, position));
+      return res.concat(pages);
     }
-    return res.concat(pages);
+    return res;
   }, []);
   // @ts-ignore
   return _orderBy(perks.filter(x=>!!x==true), `pickCount`, [`desc`]);

--- a/src/main/views/teammate/summonerDetail.vue
+++ b/src/main/views/teammate/summonerDetail.vue
@@ -42,7 +42,7 @@ const existChampList = teammateStore.masteryChampList[index]
       <n-tab-pane v-if="analysisData!==null" name="数据分析" tab="数据分析">
         <match-analysis :analysis-data="analysisData" :page-type="0"/>
       </n-tab-pane>
-      <n-tab-pane name="绝活英雄" tab="绝活英雄" display-direc tive="show">
+      <n-tab-pane name="绝活英雄" tab="绝活英雄" display-directive="show">
         <summoner-mastery-champ
           :max-h="378" :p-right="14"
           :puuid="sumInfo.puuid" :exist-champ-list="existChampList"/>

--- a/src/main/views/teammate/summonerMatchLoad.vue
+++ b/src/main/views/teammate/summonerMatchLoad.vue
@@ -16,7 +16,7 @@ import {NLayout, NLayoutContent, NLayoutSider, NSkeleton, NSpace} from "naive-ui
           <div class="flex justify-between">
             <n-skeleton v-for="i in [0,1,2,3,4,5,6]" class="imgItem" :sharp="false" />
           </div>
-        </n-layout-content class="dark:bg-[#2C2C32]">
+        </n-layout-content>
         <n-layout-content style="margin-top: 7px;">
           <div class="flex justify-between">
             <n-skeleton style="width: 100%;height: 18px" />

--- a/src/main/views/teammate/utils.ts
+++ b/src/main/views/teammate/utils.ts
@@ -132,9 +132,9 @@ const fetchSummonerInfoWithRetry = async (
 export const findTopChamp = (
 	match: SimpleMatchTypes[] | undefined | null,
 ): RencentDataAnalysisTypes | null => {
-	if (match === undefined || match === null) {
+	if (match === undefined || match === null || match.length === 0) {
 		return null;
-    }
+	}
 
 	const oneGameId = match[0].gameId;
 	// 使用 Map 统计每个 champId 出现的次数

--- a/src/queryMatch/common/matchConHeader.vue
+++ b/src/queryMatch/common/matchConHeader.vue
@@ -53,8 +53,8 @@ const {titleList} = defineProps<{
     <n-gi>
       <n-space vertical align="center">
         <text class="text-gray-400">经济差距</text>
-        <text v-if="titleList[6]>titleList[7]" style="color: #FF6666">{{ (titleList[6]-titleList[7] ).toFixed(1)}} K</text>
-        <text v-else style="color: #66B3FF">{{ (titleList[7]-titleList[6] ).toFixed(1)}} K</text>
+        <text v-if="Number(titleList[6]) > Number(titleList[7])" style="color: #FF6666">{{ (Number(titleList[6]) - Number(titleList[7])).toFixed(1) }} K</text>
+        <text v-else style="color: #66B3FF">{{ (Number(titleList[7]) - Number(titleList[6])).toFixed(1) }} K</text>
       </n-space>
     </n-gi>
   </n-grid>

--- a/src/recentMatch/utils/querySummoner.ts
+++ b/src/recentMatch/utils/querySummoner.ts
@@ -28,12 +28,8 @@ class QuerySummoner {
     }
     const isTeamOne = this.matchSession.gameData.teamOne.find((i: TeamData) => i.summonerId === this.currentId) !== undefined?true:false
     const [friendList,enemyList] = await Promise.all([
-      isTeamOne === true
-        ? await this.simplifySummonerInfo(this.matchSession.gameData.teamOne)
-        : await this.simplifySummonerInfo(this.matchSession.gameData.teamTwo),
-      isTeamOne === true
-        ? await this.simplifySummonerInfo(this.matchSession.gameData.teamTwo)
-        : await this.simplifySummonerInfo(this.matchSession.gameData.teamOne)
+      this.simplifySummonerInfo(isTeamOne ? this.matchSession.gameData.teamOne : this.matchSession.gameData.teamTwo),
+      this.simplifySummonerInfo(isTeamOne ? this.matchSession.gameData.teamTwo : this.matchSession.gameData.teamOne)
     ])
     return {friendList, enemyList,queueId:this.queueId}
   }
@@ -130,7 +126,7 @@ class QuerySummoner {
 
     if (champIndex !== -1) {
       return {
-        label: champIndex < 3 ? 'Z' : 'B',
+        label: champIndex < 3 ? 'A' : 'B',
         lv: curChampMark.lv,
         score: curChampMark.score,
       };

--- a/src/resources/champList.ts
+++ b/src/resources/champList.ts
@@ -1789,10 +1789,6 @@ export const optionsChampion = [
         label: "不落魔锋",
     },
     {
-        value: "904",
-        label: "不落魔锋",
-    },
-    {
         value: "805",
         label: "灰烬驱魔人",
     },


### PR DESCRIPTION
- **Fixed Rust backend panics in `src-tauri/src/lcu.rs`**: Replaced unsafe `.unwrap()` and `.expect()` calls in `invoke_lcu`, `get_match_list`, and `listen_for_client_start` with structured `match` error handling and fallback defaults. In `invoke_lcu`, calling `.expect()` on `serde_json::from_str(body)` caused fatal panics whenever an empty string `""` was passed from frontend defaults. In `get_match_list`, `.expect("Failed to Url")` crashed the entire desktop process whenever the LCU endpoint returned 4xx/5xx or when the game client closed mid-request. Also replaced synchronous `thread::sleep` with `tokio::time::sleep.await` inside the client listener task to avoid blocking Tokio executor worker threads.
- **Removed rogue character in `src/main/views/record/summonerEnd.vue`**: Removed a stray `2` character on line 1 before `<script setup lang="ts">` that violated Vue Single-File Component grammar and triggered template compilation errors.
- **Fixed assignment expressions in switch cases in `src/main/views/rank/index.vue` and `src/main/views/rank/utils.ts`**: Replaced assignment syntax (`case pos = 'top':` and `case (lane = "top"):`) with string literals (`case 'top':`). In JavaScript, `case pos = 'top':` mutates `pos` to `'top'` before comparison, causing the switch statement to always match the first branch and display "上单数据更新成功" regardless of the lane selected by the user. Removed the unused `arDZ` import in `src/main/views/rank/index.vue`.
- **Corrected lexicographical string comparison in `src/queryMatch/common/matchConHeader.vue`**: Cast `titleList[6]` and `titleList[7]` to `Number()` before performing the greater-than check and subtraction. Because both properties are strings, raw `>` performed a lexicographical comparison (e.g., `"9.5" > "50.0"` evaluated to `true`), causing false economic difference states and rendering negative numbers with red styling.
- **Guarded against empty match arrays in `src/main/views/teammate/utils.ts`**: Added an empty array check (`match.length === 0`) in `findTopChamp`. When a player had no recorded matches, passing `[]` bypassed the null check and caused `match[0].gameId` to throw an unhandled `TypeError: Cannot read properties of undefined (reading 'gameId')`.
- **Fixed mastery tier assignment and query parallelization in `src/recentMatch/utils/querySummoner.ts`**: Updated `champIndex < 3 ? 'Z' : 'B'` to assign `'A'` (绝活) to a summoner's top 3 mastery champions. Previously, top 3 champions received `'Z'` (normal), preventing the mastery badge from ever appearing for a player's primary champions. Removed inner `await` keywords within the array passed to `Promise.all` in `fromLcuQuery` so both friend and enemy team profiles fetch in parallel rather than sequentially.
- **Corrected invalid template syntax in `src/main/views/teammate/summonerDetail.vue` and `src/main/views/teammate/summonerMatchLoad.vue`**: Fixed a space in `display-direc tive="show"` that prevented Naive UI from recognizing the caching directive, and removed invalid attributes from the closing tag `</n-layout-content class="dark:bg-[#2C2C32]">` in `summonerMatchLoad.vue`.
- **Fixed broken import path in `src/main/views/record/addBlackList.vue`**: Changed the import path for `sumInfoTypes` from `@/background/utils/backgroundTypes` (which does not exist) to `@/background/types`, resolving TypeScript compilation errors.
- **Removed duplicate select option in `src/resources/champList.ts`**: Removed the duplicate entry `{ value: "904", label: "不落魔锋" }` from `optionsChampion` to eliminate duplicate key warnings in Naive UI select menus.
- **Fixed variable scoping and undefined array concatenation in `src/main/views/rune/get101Runes.ts`**: Scoped `pages` with `const` inside the `l.hold3 !== ''` block and returned `res` directly when `hold3` is empty, preventing `undefined` items from being concatenated into the returned rune list.